### PR TITLE
Map compose bot to host UID

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,9 +19,9 @@ services:
     #         - capabilities: [gpu]
 
   bot:
-    build: .
     image: ollamarama-matrix:latest
     container_name: ollamarama
+    user: "${UID:-1000}:${GID:-1000}"
     depends_on:
       - ollama
     environment:

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -62,6 +62,15 @@ This repo includes a `docker-compose.yml` that starts both Ollama and the bot.
 docker compose up -d --build
 ```
 
+By default the compose file runs the bot container with your host UID and GID for easier file permissions when writing to `./store`.
+If your user is not `1000:1000`, export matching values before starting compose:
+
+```bash
+export UID=$(id -u)
+export GID=$(id -g)
+docker compose up -d --build
+```
+
 3) Follow logs:
 
 ```bash


### PR DESCRIPTION
## Summary
- update docker-compose to drop the local build context and run the bot container with the caller's UID/GID by default
- document how to export UID and GID when bringing the stack up with docker compose

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5e6e26b2883278f162d1b51f07ad8