### PR TITLE
Add Docker Hub CI workflow

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -1,0 +1,47 @@
+name: Build and Push to Docker Hub
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+  workflow_dispatch:
+
+env:
+  IMAGE_NAME: ${{ secrets.DOCKERHUB_USERNAME }}/ollamarama-matrix
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow to build and push Docker images to Docker Hub
- Triggers on pushes to `main`, version tags (`v*`), and manual dispatch
- Tags images with `latest`, semver versions, and commit SHA
- Uses Buildx with GitHub Actions cache for faster builds

## Test plan
- [ ] Add `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` repository secrets
- [ ] Merge and verify the image appears on Docker Hub
- [ ] Test manual dispatch via Actions tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)