### PR TITLE
Add PyPI publish workflow

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,0 +1,31 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: pypi
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install build tools
+        run: pip install build
+
+      - name: Build package
+        run: python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,12 +10,25 @@ readme = "README.md"
 requires-python = ">=3.7"
 authors = [{ name = "Dustin Whyte" }]
 license = { file = "LICENSE" }
+keywords = ["matrix", "chatbot", "ollama", "ai", "llm"]
+classifiers = [
+  "Development Status :: 5 - Production/Stable",
+  "Environment :: No Input/Output (Daemon)",
+  "License :: OSI Approved :: GNU Affero General Public License v3",
+  "Programming Language :: Python :: 3",
+  "Topic :: Communications :: Chat",
+]
 dependencies = [
   "matrix-nio[e2e]",
   "markdown",
   "requests",
   "rich",
 ]
+
+[project.urls]
+Homepage = "https://github.com/h1ddenpr0cess20/ollamarama-matrix"
+Repository = "https://github.com/h1ddenpr0cess20/ollamarama-matrix"
+Issues = "https://github.com/h1ddenpr0cess20/ollamarama-matrix/issues"
 
 [project.scripts]
 ollamarama-matrix = "ollamarama.cli:main"


### PR DESCRIPTION
## Summary
- Adds GitHub Actions workflow for publishing to PyPI via trusted publishing on GitHub releases
- Enhances pyproject.toml with keywords, classifiers, and project URLs for PyPI listing

## Setup
1. Register a pending publisher on [pypi.org](https://pypi.org/manage/account/publishing/) — owner: `h1ddenpr0cess20`, repo: `ollamarama-matrix`, workflow: `pypi-publish.yml`, environment: `pypi`
2. Create a `pypi` environment in repo settings

## Test plan
- [ ] Configure trusted publisher on PyPI
- [ ] Create a GitHub release and verify package appears on PyPI
- [ ] Test `pip install ollamarama-matrix` from PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)