### PR TITLE
Fix Docker MCP networking with host network mode

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,11 +22,10 @@ services:
     image: ollamarama-matrix:latest
     container_name: ollamarama
     user: "${UID:-1000}:${GID:-1000}"
-    depends_on:
-      - ollama
+    network_mode: host
     environment:
       OLLAMARAMA_LOG_LEVEL: INFO
-      OLLAMARAMA_OLLAMA_URL: http://ollama:11434/api/chat
+      OLLAMARAMA_OLLAMA_URL: http://localhost:11434/api/chat
     volumes:
       - ./config.json:/data/config.json:ro
       - ./store:/data/store
@@ -34,4 +33,3 @@ services:
 
 volumes:
   ollama:
-

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -32,14 +32,14 @@ mkdir -p store
 cp config.json ./config.json  # ensure it contains Matrix creds, rooms, models
 ```
 
-2) Run the container (connects to an existing Ollama server):
+2) Run the container with `--network host` so it can reach Ollama and any local MCP servers on the host:
 
 ```bash
 docker run --rm -it \
   --name ollamarama \
+  --network host \
   -v "$(pwd)/config.json":/data/config.json:ro \
   -v "$(pwd)/store":/data/store \
-  -e OLLAMARAMA_OLLAMA_URL=http://<host>:11434/api/chat \
   -e OLLAMARAMA_LOG_LEVEL=INFO \
   ollamarama-matrix:latest
 ```
@@ -51,14 +51,14 @@ Notes:
 ```powershell
 docker run --rm -it `
   --name ollamarama `
+  --network host `
   -v "${PWD}/config.json:/data/config.json:ro" `
   -v "${PWD}/store:/data/store" `
-  -e OLLAMARAMA_OLLAMA_URL=http://<host>:11434/api/chat `
   -e OLLAMARAMA_LOG_LEVEL=INFO `
   ollamarama-matrix:latest
 ```
 
-- Replace `<host>` with your Ollama server host if not local.
+- `--network host` shares the host's network stack with the container, so `localhost` URLs in your config (Ollama, MCP servers) work directly.
 - The bot does not expose ports; it connects out to Matrix and Ollama.
 - Persist `/data/store` to retain device keys for E2E rooms.
 
@@ -66,7 +66,7 @@ docker run --rm -it `
 
 This repo includes a `docker-compose.yml` that starts both Ollama and the bot.
 
-1) Ensure your `config.json` is present at the repo root and contains Matrix credentials, channels, and model selection. The compose file overrides `ollama.api_url` with `http://ollama:11434/api/chat`.
+1) Ensure your `config.json` is present at the repo root and contains Matrix credentials, channels, and model selection. The compose file uses `network_mode: host` for the bot so localhost URLs (Ollama, MCP servers) work directly.
 
 2) Start services:
 
@@ -103,6 +103,12 @@ docker exec -it ollama ollama pull qwen3
 ### GPU (optional)
 
 If you have NVIDIA GPUs, install the NVIDIA Container Toolkit and uncomment the `deploy.resources.reservations.devices` stanza under the `ollama` service in `docker-compose.yml`.
+
+## MCP Servers
+
+Local MCP servers work in Docker thanks to `--network host` (or `network_mode: host` in Compose), which shares the host's network stack with the container. Any MCP server running on the host and configured with a `localhost` or `127.0.0.1` URL in `config.json` is reachable without extra setup.
+
+For stdio/command‑based MCP servers (e.g. `uvx`, `npx`), the binary must be installed inside the container image. Prefer URL‑based MCP servers when running in Docker.
 
 ## Configuration
 

--- a/docs/tools-and-mcp.md
+++ b/docs/tools-and-mcp.md
@@ -117,10 +117,15 @@ Behavior notes:
 - Start the bot with `-L DEBUG` to see detailed logs.
 - Look for lines like `MCP server 'name' returned N tool(s)` and subsequent `Tool (MCP)` call logs when the model uses a tool.
 
+### Docker
+
+When running in Docker, use `--network host` so the container can reach MCP servers on localhost. See [Docker](docker.md) for details. Stdio/command‑based MCP servers require the binary to be installed in the container image; prefer URL‑based servers when running in Docker.
+
 ## Troubleshooting
 
 - Model never calls tools: ensure your model supports tool/function calling and that tools appear in logs at startup (or run with `-L DEBUG`).
 - HTTP/network errors from tools: check your environment’s network and any proxies/firewalls. MCP servers must be reachable.
+- MCP tools not loading in Docker: make sure you’re using `--network host`. See [Docker](docker.md).
 - Builtin tool not found: confirm the function name in `schema.json` matches the Python function name and that the module is importable.
 
 ## Security Considerations

--- a/tests/test_tools_mcp.py
+++ b/tests/test_tools_mcp.py
@@ -19,7 +19,7 @@ class FakeTool:
 
 class FakeMCPClient:
     def __init__(self, cfg):
-        pass
+        self.transport = None
 
     async def __aenter__(self):
         return self


### PR DESCRIPTION
## Summary
- Use `--network host` / `network_mode: host` so the bot container shares the host's network stack, making localhost MCP servers and Ollama reachable directly
- Update Docker and MCP docs with `--network host` usage
- Fix pre-existing `FakeMCPClient` test failure (missing `transport` attribute)

Closes #56

## Test plan
- [x] Full test suite passes (37/37)
- [x] Verified MCP server loads successfully in Docker with `--network host`

🤖 Generated with [Claude Code](https://claude.com/claude-code)