### PR TITLE
Add thinking emoji reaction indicator + fix markdown list rendering

### DIFF
--- a/ollamarama/__init__.py
+++ b/ollamarama/__init__.py
@@ -4,4 +4,4 @@ Provides the CLI and application modules for the Matrix bot.
 """
 
 __all__ = ["__version__"]
-__version__ = "1.2.0"
+__version__ = "1.2.1"

--- a/ollamarama/app_context.py
+++ b/ollamarama/app_context.py
@@ -12,6 +12,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 from .config import AppConfig
 from .fastmcp_client import FastMCPClient
 from .history import HistoryStore
+from .markdown_utils import render_markdown
 from .matrix_client import MatrixClientWrapper
 from .ollama_client import OllamaClient
 from .tools import execute_tool, load_schema
@@ -208,6 +209,7 @@ class AppContext:
 
     def _init_tool_calling(self, cfg: AppConfig) -> None:
         """Configure tool calling state and tool schema."""
+        self.thinking_indicator: Optional[asyncio.Task] = None  # type: ignore[type-arg]
         self.tools_enabled = True
         builtin_schema = self._load_builtin_tools_schema()
         mcp_schema, mcp_tool_names, mcp_client = self._probe_mcp_tools(cfg)
@@ -260,15 +262,17 @@ class AppContext:
         """
         if not self.cfg.markdown:
             return None
-        try:
-            import markdown as _md
+        return render_markdown(body)
 
-            return _md.markdown(
-                body,
-                extensions=["extra", "fenced_code", "nl2br", "sane_lists", "tables", "codehilite"],
-            )
-        except Exception:
-            return None
+    async def clear_thinking_indicator(self) -> None:
+        """Cancel and await the active thinking indicator task if one is running."""
+        indicator = self.thinking_indicator
+        if indicator and not indicator.done():
+            indicator.cancel()
+            try:
+                await indicator
+            except asyncio.CancelledError:
+                pass
 
     def _execute_tool(self, name: str, arguments: Dict[str, Any]) -> str:
         """Execute a tool call, preferring MCP tools when available.

--- a/ollamarama/app_context.py
+++ b/ollamarama/app_context.py
@@ -106,8 +106,10 @@ class AppContext:
     def _expose_config_fields(self, cfg: AppConfig) -> None:
         """Expose frequently used config fields on the context."""
         self.models = cfg.ollama.models
-        self.default_model = cfg.ollama.default_model
-        self.model = cfg.ollama.default_model
+        models = cfg.ollama.models or {}
+        resolved = models.get(cfg.ollama.default_model, cfg.ollama.default_model)
+        self.default_model = resolved
+        self.model = resolved
         self.default_personality = cfg.ollama.personality
         self.personality = cfg.ollama.personality
         self.options = cfg.ollama.options

--- a/ollamarama/app_runtime.py
+++ b/ollamarama/app_runtime.py
@@ -48,9 +48,12 @@ async def thinking_indicator(matrix: MatrixClientWrapper, room_id: str, target_e
             await asyncio.sleep(half)
             idx += 1
     except asyncio.CancelledError:
-        for reaction_id in reaction_ids:
-            if reaction_id:
-                await matrix.redact_event(room_id, reaction_id)
+        pending = [rid for rid in reaction_ids if rid]
+        if pending:
+            await asyncio.gather(
+                *(matrix.redact_event(room_id, rid) for rid in pending),
+                return_exceptions=True,
+            )
         raise
 
 

--- a/ollamarama/app_runtime.py
+++ b/ollamarama/app_runtime.py
@@ -41,10 +41,10 @@ async def thinking_indicator(matrix: MatrixClientWrapper, room_id: str, target_e
             current = reaction_ids[slot]
             if current:
                 await matrix.redact_event(room_id, current)
-                reaction_ids[slot] = None
             await asyncio.sleep(half)
             new_id = await matrix.send_reaction(room_id, target_event_id, _THINKING_EMOJIS[slot])
-            reaction_ids[slot] = new_id
+            if new_id:
+                reaction_ids[slot] = new_id
             await asyncio.sleep(half)
             idx += 1
     except asyncio.CancelledError:

--- a/ollamarama/app_runtime.py
+++ b/ollamarama/app_runtime.py
@@ -10,8 +10,48 @@ from typing import Any, Callable, Optional
 from .app_context import AppContext
 from .app_router import _build_router
 from .config import AppConfig
+from .handlers.cmd_ai import handle_ai
+from .handlers.cmd_prompt import handle_custom, handle_persona
+from .handlers.cmd_x import handle_x
 from .handlers.router import Router
+from .matrix_client import MatrixClientWrapper
 from .security import Security
+
+_THINKING_EMOJIS = ["🤔", "💭", "🧠"]
+_THINKING_INTERVAL = 4.5
+_GENERATING_HANDLERS = {handle_ai, handle_x, handle_persona, handle_custom}
+
+
+async def thinking_indicator(matrix: MatrixClientWrapper, room_id: str, target_event_id: str) -> None:
+    """React to the user's message with cycling emojis while the bot processes.
+
+    Adds emojis one at a time, then cycles them until cancelled, at which point
+    all reactions are redacted.
+    """
+    reaction_ids: list[Optional[str]] = [None] * len(_THINKING_EMOJIS)
+    try:
+        for idx, emoji in enumerate(_THINKING_EMOJIS):
+            reaction_id = await matrix.send_reaction(room_id, target_event_id, emoji)
+            reaction_ids[idx] = reaction_id
+            await asyncio.sleep(_THINKING_INTERVAL)
+        idx = 0
+        half = _THINKING_INTERVAL / 2
+        while True:
+            slot = idx % len(_THINKING_EMOJIS)
+            current = reaction_ids[slot]
+            if current:
+                await matrix.redact_event(room_id, current)
+                reaction_ids[slot] = None
+            await asyncio.sleep(half)
+            new_id = await matrix.send_reaction(room_id, target_event_id, _THINKING_EMOJIS[slot])
+            reaction_ids[slot] = new_id
+            await asyncio.sleep(half)
+            idx += 1
+    except asyncio.CancelledError:
+        for reaction_id in reaction_ids:
+            if reaction_id:
+                await matrix.redact_event(room_id, reaction_id)
+        raise
 
 
 async def _persist_device_id_if_needed(ctx: AppContext, cfg: AppConfig, config_path: Optional[str]) -> None:
@@ -169,9 +209,27 @@ def _make_text_handler(
                 await security.allow_devices(sender)
             except Exception:
                 pass
-            res = handler(*args)
-            if asyncio.iscoroutine(res):
-                await res
+            user_event_id = getattr(event, "event_id", None)
+            should_indicate = handler in _GENERATING_HANDLERS and user_event_id
+            if should_indicate:
+                indicator = asyncio.create_task(
+                    thinking_indicator(ctx.matrix, room.room_id, user_event_id)  # type: ignore
+                )
+                ctx.thinking_indicator = indicator
+            else:
+                indicator = None
+            try:
+                res = handler(*args)
+                if asyncio.iscoroutine(res):
+                    await res
+            finally:
+                if indicator:
+                    indicator.cancel()
+                    try:
+                        await indicator
+                    except asyncio.CancelledError:
+                        pass
+                ctx.thinking_indicator = None
         except Exception as e:
             ctx.log(e)
 

--- a/ollamarama/handlers/cmd_ai.py
+++ b/ollamarama/handlers/cmd_ai.py
@@ -37,6 +37,9 @@ async def handle_ai(ctx: Any, room_id: str, sender_id: str, sender_display: str,
             response_text = data.get("message", {}).get("content", "")
     except Exception as e:
         try:
+            clear_indicator = getattr(ctx, "clear_thinking_indicator", None)
+            if clear_indicator:
+                await clear_indicator()
             await matrix.send_text(room_id, "Something went wrong", html=ctx.render("Something went wrong"))
             ctx.log(e)
         except Exception:
@@ -74,4 +77,7 @@ async def handle_ai(ctx: Any, room_id: str, sender_id: str, sender_display: str,
         ctx.log(f"Sending response to {sender_display} in {room_id}: {body}")
     except Exception:
         pass
+    clear_indicator = getattr(ctx, "clear_thinking_indicator", None)
+    if clear_indicator:
+        await clear_indicator()
     await matrix.send_text(room_id, body, html=html)

--- a/ollamarama/handlers/cmd_prompt.py
+++ b/ollamarama/handlers/cmd_prompt.py
@@ -85,6 +85,9 @@ async def _respond(ctx: Any, room_id: str, user_id: str, header_display: str) ->
         )
     except Exception as e:
         try:
+            clear_indicator = getattr(ctx, "clear_thinking_indicator", None)
+            if clear_indicator:
+                await clear_indicator()
             await ctx.matrix.send_text(room_id, "Something went wrong", html=ctx.render("Something went wrong"))
             ctx.log(e)
         except Exception:
@@ -123,4 +126,7 @@ async def _respond(ctx: Any, room_id: str, user_id: str, header_display: str) ->
         ctx.log(f"Sending response to {header_display} in {room_id}: {body}")
     except Exception:
         pass
+    clear_indicator = getattr(ctx, "clear_thinking_indicator", None)
+    if clear_indicator:
+        await clear_indicator()
     await ctx.matrix.send_text(room_id, body, html=html)

--- a/ollamarama/handlers/cmd_x.py
+++ b/ollamarama/handlers/cmd_x.py
@@ -71,6 +71,9 @@ async def handle_x(ctx: Any, room_id: str, sender_id: str, sender_display: str, 
         )
     except Exception as e:
         try:
+            clear_indicator = getattr(ctx, "clear_thinking_indicator", None)
+            if clear_indicator:
+                await clear_indicator()
             await ctx.matrix.send_text(room_id, "Something went wrong", html=ctx.render("Something went wrong"))
             ctx.log(e)
         except Exception:
@@ -104,4 +107,7 @@ async def handle_x(ctx: Any, room_id: str, sender_id: str, sender_display: str, 
         ctx.log(f"Sending response to {sender_display} in {room_id}: {body}")
     except Exception:
         pass
+    clear_indicator = getattr(ctx, "clear_thinking_indicator", None)
+    if clear_indicator:
+        await clear_indicator()
     await ctx.matrix.send_text(room_id, body, html=html)

--- a/ollamarama/markdown_utils.py
+++ b/ollamarama/markdown_utils.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+import markdown
+
+
+MATRIX_MARKDOWN_EXTENSIONS = [
+    "extra",
+    "fenced_code",
+    "nl2br",
+    "sane_lists",
+    "tables",
+]
+
+_LIST_ITEM_RE = re.compile(r"^(\s*([-*+]|\d+[.)]))(\s|$)")
+_OL_MARKER_RE = re.compile(r"^\s*\d+[.)]")
+
+
+def _list_key(line: str) -> tuple[int, str] | None:
+    """Return (indent, kind) for a list item line, or None if not a list item."""
+    if not _LIST_ITEM_RE.match(line):
+        return None
+    indent = len(line) - len(line.lstrip())
+    kind = "ol" if _OL_MARKER_RE.match(line) else "ul"
+    return (indent, kind)
+
+
+def _normalize_list_spacing(body: str) -> str:
+    """Fix list spacing for Matrix rendering with nl2br.
+
+    1. Insert a blank line before the first list item when it immediately
+       follows a paragraph (nl2br would otherwise swallow the list markers).
+    2. Remove blank lines between consecutive items of the same list (same
+       indent + marker type), preventing loose-list <p> wrappers that cause
+       some Matrix clients to render the number on a separate line.
+    """
+    lines = body.splitlines()
+
+    # Pass 1: ensure blank line before list that follows paragraph text
+    step1: list[str] = []
+    for i, line in enumerate(lines):
+        if i > 0 and _LIST_ITEM_RE.match(line):
+            prev = lines[i - 1]
+            if prev.strip() and not _LIST_ITEM_RE.match(prev):
+                step1.append("")
+        step1.append(line)
+
+    # Pass 2: collapse blank lines between items of the same list
+    n = len(step1)
+    out: list[str] = []
+    for i, line in enumerate(step1):
+        if not line.strip():
+            prev_nb = next((step1[j] for j in range(i - 1, -1, -1) if step1[j].strip()), "")
+            next_nb = next((step1[j] for j in range(i + 1, n) if step1[j].strip()), "")
+            if _list_key(prev_nb) and _list_key(prev_nb) == _list_key(next_nb):
+                continue
+        out.append(line)
+
+    return "\n".join(out)
+
+
+def _unwrap_li_paragraphs(html: str) -> str:
+    """Remove <p> wrappers that are the first child of <li> elements.
+
+    When loose Markdown lists are rendered, each <li> gets a <p> child.
+    Several Matrix clients (e.g. Element) render <li><p>text</p> with the
+    list marker on its own line, detached from the content. Stripping the
+    leading <p> (and the trailing </p> when it directly precedes </li>)
+    keeps the number/bullet on the same line as the content.
+    """
+    html = re.sub(r"(<li[^>]*>)\s*<p>", r"\1", html)
+    html = re.sub(r"</p>(\s*</li>)", r"\1", html)
+    return html
+
+
+def render_markdown(body: str) -> Optional[str]:
+    """Render Markdown to Matrix-safe HTML.
+
+    Avoid ``codehilite`` here. It emits ``div``/``span``-heavy HTML that Matrix
+    clients frequently sanitize in ways that break fenced code blocks.
+    """
+    try:
+        html = markdown.markdown(_normalize_list_spacing(body), extensions=MATRIX_MARKDOWN_EXTENSIONS)  # type: ignore[arg-type]
+        return _unwrap_li_paragraphs(html)
+    except Exception:
+        return None

--- a/ollamarama/matrix_client.py
+++ b/ollamarama/matrix_client.py
@@ -77,6 +77,33 @@ class MatrixClientWrapper:
             content.update({"format": "org.matrix.custom.html", "formatted_body": html})
         await self.client.room_send(room_id=room_id, message_type="m.room.message", content=content, ignore_unverified_devices=True)
 
+    async def send_reaction(self, room_id: str, event_id: str, key: str) -> Optional[str]:
+        """Send a reaction emoji to an event and return its event ID, or None on failure."""
+        content = {
+            "m.relates_to": {
+                "rel_type": "m.annotation",
+                "event_id": event_id,
+                "key": key,
+            }
+        }
+        try:
+            resp = await self.client.room_send(
+                room_id=room_id,
+                message_type="m.reaction",
+                content=content,
+                ignore_unverified_devices=True,
+            )
+            return getattr(resp, "event_id", None)
+        except Exception:
+            return None
+
+    async def redact_event(self, room_id: str, event_id: str) -> None:
+        """Redact (delete) an event by its ID."""
+        try:
+            await self.client.room_redact(room_id=room_id, event_id=event_id)
+        except Exception:
+            pass
+
     async def display_name(self, user_id: str) -> str:
         """Fetch and return the display name for a user, or the ID on failure.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ollamarama-matrix"
-version = "1.2.0"
+version = "1.2.1"
 description = "Matrix chatbot powered by Ollama"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -20,11 +20,9 @@ def make_cfg(markdown=True):
 
 
 def test_render_html_success(monkeypatch):
-    class FakeMarkdownMod:
-        def markdown(self, text, extensions=None):
-            return "<p>" + text + "</p>"
+    import ollamarama.markdown_utils as mu
 
-    monkeypatch.setitem(sys.modules, "markdown", FakeMarkdownMod())
+    monkeypatch.setattr(mu, "render_markdown", lambda body: "<p>" + body + "</p>")
     # Patch matrix client deps so AppContext can construct without nio
     class _FakeCfg:
         def __init__(self, **kw):


### PR DESCRIPTION
Closes #66

## Summary

- Adds a thinking emoji indicator that animates while the bot processes a message (reacts to the user's message with cycling 🤔/💭/🧠 emojis, removed when the reply is sent)
- Fixes markdown list rendering issues caused by the `nl2br` extension:
  - Lists immediately following paragraph text were rendered as plain text with `<br>` instead of `<ul>`/`<ol>`
  - Loose lists (blank lines between items, common in LLM output) wrapped each `<li>` in `<p>`, causing Matrix clients to render the list number on a separate line from its content
  - Drops `codehilite` from the extension list, which emits `div`/`span`-heavy HTML that Matrix clients frequently sanitize in ways that break fenced code blocks

## Test plan

- [ ] Send a message and verify the thinking emoji reaction appears and is removed when the bot replies
- [ ] Ask the bot for a numbered list and verify numbers appear on the same line as their content
- [ ] Ask the bot for a bulleted list after a line of text (no blank line) and verify it renders as a proper list
- [ ] Ask the bot for a list with blank lines between items and verify tight rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)