### PR TITLE
Add thinking placeholder with animated dot-wave indicator

### DIFF
--- a/ollamarama/app_context.py
+++ b/ollamarama/app_context.py
@@ -12,6 +12,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 from .config import AppConfig
 from .fastmcp_client import FastMCPClient
 from .history import HistoryStore
+from .markdown_utils import render_markdown
 from .matrix_client import MatrixClientWrapper
 from .ollama_client import OllamaClient
 from .tools import execute_tool, load_schema
@@ -105,8 +106,10 @@ class AppContext:
     def _expose_config_fields(self, cfg: AppConfig) -> None:
         """Expose frequently used config fields on the context."""
         self.models = cfg.ollama.models
-        self.default_model = cfg.ollama.default_model
-        self.model = cfg.ollama.default_model
+        models = cfg.ollama.models or {}
+        resolved = models.get(cfg.ollama.default_model, cfg.ollama.default_model)
+        self.default_model = resolved
+        self.model = resolved
         self.default_personality = cfg.ollama.personality
         self.personality = cfg.ollama.personality
         self.options = cfg.ollama.options
@@ -208,6 +211,8 @@ class AppContext:
 
     def _init_tool_calling(self, cfg: AppConfig) -> None:
         """Configure tool calling state and tool schema."""
+        self.thinking_placeholder_event_id: Optional[str] = None
+        self.thinking_animation_task: Optional[asyncio.Task] = None  # type: ignore[type-arg]
         self.tools_enabled = True
         builtin_schema = self._load_builtin_tools_schema()
         mcp_schema, mcp_tool_names, mcp_client = self._probe_mcp_tools(cfg)
@@ -260,15 +265,30 @@ class AppContext:
         """
         if not self.cfg.markdown:
             return None
-        try:
-            import markdown as _md
+        return render_markdown(body)
 
-            return _md.markdown(
-                body,
-                extensions=["extra", "fenced_code", "nl2br", "sane_lists", "tables", "codehilite"],
-            )
-        except Exception:
-            return None
+    async def send_response(self, room_id: str, body: str, html: Optional[str] = None) -> None:
+        """Send the response, editing the thinking placeholder if one exists.
+
+        Args:
+            room_id: Target room ID.
+            body: Plain-text message body.
+            html: Optional HTML-formatted body.
+        """
+        task = self.thinking_animation_task
+        self.thinking_animation_task = None
+        if task and not task.done():
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+        placeholder = self.thinking_placeholder_event_id
+        self.thinking_placeholder_event_id = None
+        if placeholder:
+            await self.matrix.edit_message(room_id, placeholder, body, html=html)
+        else:
+            await self.matrix.send_text(room_id, body, html=html)
 
     def _execute_tool(self, name: str, arguments: Dict[str, Any]) -> str:
         """Execute a tool call, preferring MCP tools when available.

--- a/ollamarama/app_runtime.py
+++ b/ollamarama/app_runtime.py
@@ -10,8 +10,31 @@ from typing import Any, Callable, Optional
 from .app_context import AppContext
 from .app_router import _build_router
 from .config import AppConfig
+from .handlers.cmd_ai import handle_ai
+from .handlers.cmd_prompt import handle_custom, handle_persona
+from .handlers.cmd_x import handle_x
 from .handlers.router import Router
 from .security import Security
+
+_GENERATING_HANDLERS = {handle_ai, handle_x, handle_persona, handle_custom}
+
+_SPINNER_PREFIX = "Thinking"
+_SPINNER_FRAMES = [".", "..", "...", ".."]
+_SPINNER_INTERVAL = 0.8
+
+
+async def _thinking_animation(matrix: Any, room_id: str, event_id: str, label: str, render_fn: Any) -> None:
+    """Cycle a dot-wave in the thinking placeholder by editing the message."""
+    try:
+        idx = 1  # frame 0 was already sent as the initial placeholder
+        while True:
+            await asyncio.sleep(_SPINNER_INTERVAL)
+            frame = _SPINNER_FRAMES[idx % len(_SPINNER_FRAMES)]
+            body = f"{label}\n{_SPINNER_PREFIX}{frame}"
+            await matrix.edit_message(room_id, event_id, body, html=render_fn(body))
+            idx += 1
+    except asyncio.CancelledError:
+        raise
 
 
 async def _persist_device_id_if_needed(ctx: AppContext, cfg: AppConfig, config_path: Optional[str]) -> None:
@@ -169,6 +192,18 @@ def _make_text_handler(
                 await security.allow_devices(sender)
             except Exception:
                 pass
+            user_event_id = getattr(event, "event_id", None)
+            if handler in _GENERATING_HANDLERS and user_event_id:
+                label = f"**{sender_display}**:"
+                initial_body = f"{label}\n{_SPINNER_PREFIX}{_SPINNER_FRAMES[0]}"
+                event_id = await ctx.matrix.send_text(
+                    room.room_id, initial_body, html=ctx.render(initial_body)  # type: ignore
+                )
+                ctx.thinking_placeholder_event_id = event_id
+                if event_id:
+                    ctx.thinking_animation_task = asyncio.create_task(
+                        _thinking_animation(ctx.matrix, room.room_id, event_id, label, ctx.render)  # type: ignore
+                    )
             res = handler(*args)
             if asyncio.iscoroutine(res):
                 await res

--- a/ollamarama/handlers/cmd_ai.py
+++ b/ollamarama/handlers/cmd_ai.py
@@ -37,7 +37,7 @@ async def handle_ai(ctx: Any, room_id: str, sender_id: str, sender_display: str,
             response_text = data.get("message", {}).get("content", "")
     except Exception as e:
         try:
-            await matrix.send_text(room_id, "Something went wrong", html=ctx.render("Something went wrong"))
+            await ctx.send_response(room_id, "Something went wrong", html=ctx.render("Something went wrong"))
             ctx.log(e)
         except Exception:
             pass
@@ -74,4 +74,4 @@ async def handle_ai(ctx: Any, room_id: str, sender_id: str, sender_display: str,
         ctx.log(f"Sending response to {sender_display} in {room_id}: {body}")
     except Exception:
         pass
-    await matrix.send_text(room_id, body, html=html)
+    await ctx.send_response(room_id, body, html=html)

--- a/ollamarama/handlers/cmd_prompt.py
+++ b/ollamarama/handlers/cmd_prompt.py
@@ -85,7 +85,7 @@ async def _respond(ctx: Any, room_id: str, user_id: str, header_display: str) ->
         )
     except Exception as e:
         try:
-            await ctx.matrix.send_text(room_id, "Something went wrong", html=ctx.render("Something went wrong"))
+            await ctx.send_response(room_id, "Something went wrong", html=ctx.render("Something went wrong"))
             ctx.log(e)
         except Exception:
             pass
@@ -123,4 +123,4 @@ async def _respond(ctx: Any, room_id: str, user_id: str, header_display: str) ->
         ctx.log(f"Sending response to {header_display} in {room_id}: {body}")
     except Exception:
         pass
-    await ctx.matrix.send_text(room_id, body, html=html)
+    await ctx.send_response(room_id, body, html=html)

--- a/ollamarama/handlers/cmd_x.py
+++ b/ollamarama/handlers/cmd_x.py
@@ -71,7 +71,7 @@ async def handle_x(ctx: Any, room_id: str, sender_id: str, sender_display: str, 
         )
     except Exception as e:
         try:
-            await ctx.matrix.send_text(room_id, "Something went wrong", html=ctx.render("Something went wrong"))
+            await ctx.send_response(room_id, "Something went wrong", html=ctx.render("Something went wrong"))
             ctx.log(e)
         except Exception:
             pass
@@ -104,4 +104,4 @@ async def handle_x(ctx: Any, room_id: str, sender_id: str, sender_display: str, 
         ctx.log(f"Sending response to {sender_display} in {room_id}: {body}")
     except Exception:
         pass
-    await ctx.matrix.send_text(room_id, body, html=html)
+    await ctx.send_response(room_id, body, html=html)

--- a/ollamarama/markdown_utils.py
+++ b/ollamarama/markdown_utils.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+import markdown
+
+
+MATRIX_MARKDOWN_EXTENSIONS = [
+    "extra",
+    "fenced_code",
+    "nl2br",
+    "sane_lists",
+    "tables",
+]
+
+_LIST_ITEM_RE = re.compile(r"^(\s*([-*+]|\d+[.)]))(\s|$)")
+_OL_MARKER_RE = re.compile(r"^\s*\d+[.)]")
+
+
+def _list_key(line: str) -> tuple[int, str] | None:
+    """Return (indent, kind) for a list item line, or None if not a list item."""
+    if not _LIST_ITEM_RE.match(line):
+        return None
+    indent = len(line) - len(line.lstrip())
+    kind = "ol" if _OL_MARKER_RE.match(line) else "ul"
+    return (indent, kind)
+
+
+def _normalize_list_spacing(body: str) -> str:
+    """Fix list spacing for Matrix rendering with nl2br.
+
+    1. Insert a blank line before the first list item when it immediately
+       follows a paragraph (nl2br would otherwise swallow the list markers).
+    2. Remove blank lines between consecutive items of the same list (same
+       indent + marker type), preventing loose-list <p> wrappers that cause
+       some Matrix clients to render the number on a separate line.
+    """
+    lines = body.splitlines()
+
+    # Pass 1: ensure blank line before list that follows paragraph text
+    step1: list[str] = []
+    for i, line in enumerate(lines):
+        if i > 0 and _LIST_ITEM_RE.match(line):
+            prev = lines[i - 1]
+            if prev.strip() and not _LIST_ITEM_RE.match(prev):
+                step1.append("")
+        step1.append(line)
+
+    # Pass 2: collapse blank lines between items of the same list
+    n = len(step1)
+    out: list[str] = []
+    for i, line in enumerate(step1):
+        if not line.strip():
+            prev_nb = next((step1[j] for j in range(i - 1, -1, -1) if step1[j].strip()), "")
+            next_nb = next((step1[j] for j in range(i + 1, n) if step1[j].strip()), "")
+            if _list_key(prev_nb) and _list_key(prev_nb) == _list_key(next_nb):
+                continue
+        out.append(line)
+
+    return "\n".join(out)
+
+
+def _unwrap_li_paragraphs(html: str) -> str:
+    """Remove <p> wrappers that are the first child of <li> elements.
+
+    When loose Markdown lists are rendered, each <li> gets a <p> child.
+    Several Matrix clients (e.g. Element) render <li><p>text</p> with the
+    list marker on its own line, detached from the content. Stripping the
+    leading <p> (and the trailing </p> when it directly precedes </li>)
+    keeps the number/bullet on the same line as the content.
+    """
+    html = re.sub(r"(<li[^>]*>)\s*<p>", r"\1", html)
+    html = re.sub(r"</p>(\s*</li>)", r"\1", html)
+    return html
+
+
+def render_markdown(body: str) -> Optional[str]:
+    """Render Markdown to Matrix-safe HTML.
+
+    Avoid ``codehilite`` here. It emits ``div``/``span``-heavy HTML that Matrix
+    clients frequently sanitize in ways that break fenced code blocks.
+    """
+    try:
+        html = markdown.markdown(_normalize_list_spacing(body), extensions=MATRIX_MARKDOWN_EXTENSIONS)  # type: ignore[arg-type]
+        return _unwrap_li_paragraphs(html)
+    except Exception:
+        return None

--- a/ollamarama/matrix_client.py
+++ b/ollamarama/matrix_client.py
@@ -64,8 +64,8 @@ class MatrixClientWrapper:
         """
         await self.client.join(room_id)
 
-    async def send_text(self, room_id: str, body: str, html: Optional[str] = None) -> None:
-        """Send a text message to a room.
+    async def send_text(self, room_id: str, body: str, html: Optional[str] = None) -> Optional[str]:
+        """Send a text message to a room and return its event ID, or None on failure.
 
         Args:
             room_id: Target room ID.
@@ -75,7 +75,34 @@ class MatrixClientWrapper:
         content = {"msgtype": "m.text", "body": body}
         if html is not None:
             content.update({"format": "org.matrix.custom.html", "formatted_body": html})
-        await self.client.room_send(room_id=room_id, message_type="m.room.message", content=content, ignore_unverified_devices=True)
+        try:
+            resp = await self.client.room_send(room_id=room_id, message_type="m.room.message", content=content, ignore_unverified_devices=True)
+            return getattr(resp, "event_id", None)
+        except Exception:
+            return None
+
+    async def edit_message(self, room_id: str, event_id: str, body: str, html: Optional[str] = None) -> None:
+        """Edit an existing message in a room using the m.replace relation.
+
+        Args:
+            room_id: Target room ID.
+            event_id: Event ID of the message to replace.
+            body: New plain-text body.
+            html: Optional new HTML body.
+        """
+        new_content: dict = {"msgtype": "m.text", "body": body}
+        if html is not None:
+            new_content.update({"format": "org.matrix.custom.html", "formatted_body": html})
+        content = {
+            **new_content,
+            "body": f"* {body}",
+            "m.relates_to": {"rel_type": "m.replace", "event_id": event_id},
+            "m.new_content": new_content,
+        }
+        try:
+            await self.client.room_send(room_id=room_id, message_type="m.room.message", content=content, ignore_unverified_devices=True)
+        except Exception:
+            pass
 
     async def display_name(self, user_id: str) -> str:
         """Fetch and return the display name for a user, or the ID on failure.

--- a/tests/test_handlers_errors.py
+++ b/tests/test_handlers_errors.py
@@ -29,6 +29,12 @@ async def _to_thread(fn, *a, **kw):
     return fn(*a, **kw)
 
 
+def _make_send_response(matrix):
+    async def send_response(room_id, body, html=None):
+        await matrix.send_text(room_id, body, html=html)
+    return send_response
+
+
 @pytest.mark.asyncio
 async def test_handle_ai_error_path_sends_message():
     ctx = SimpleNamespace(
@@ -42,6 +48,7 @@ async def test_handle_ai_error_path_sends_message():
         timeout=5,
         log=lambda *a, **k: None,
     )
+    ctx.send_response = _make_send_response(ctx.matrix)
     await handle_ai(ctx, "!r", "@u", "User", "hello")
     assert ctx.matrix.sent, "should send error message"
     assert "Something went wrong" in ctx.matrix.sent[-1][1]
@@ -60,6 +67,7 @@ async def test_handle_x_error_path_sends_message():
         timeout=5,
         log=lambda *a, **k: None,
     )
+    ctx.send_response = _make_send_response(ctx.matrix)
     # Seed a target with history so handler proceeds
     ctx.history.add("!r", "@t", "user", "hi")
     await handle_x(ctx, "!r", "@s", "Sender", "@t hello")

--- a/tests/test_handlers_model_ai_help.py
+++ b/tests/test_handlers_model_ai_help.py
@@ -29,6 +29,12 @@ async def _to_thread(fn, *a, **kw):
     return fn(*a, **kw)
 
 
+def _make_send_response(matrix):
+    async def send_response(room_id, body, html=None):
+        await matrix.send_text(room_id, body, html=html)
+    return send_response
+
+
 @pytest.mark.asyncio
 async def test_handle_model_show_and_set_and_reset():
     ctx = SimpleNamespace(
@@ -69,6 +75,7 @@ async def test_handle_ai_strips_thinking_markers():
         timeout=10,
         log=lambda *a, **k: None,
     )
+    ctx.send_response = _make_send_response(ctx.matrix)
     await handle_ai(ctx, "!r", "@u", "User", "hello")
     # Ensure the sent body does not contain think/thought markers
     sent_body = ctx.matrix.sent[-1][1]
@@ -89,6 +96,7 @@ async def test_handle_ai_trims_whitespace_simple():
         timeout=10,
         log=lambda *a, **k: None,
     )
+    ctx.send_response = _make_send_response(ctx.matrix)
     await handle_ai(ctx, "!r", "@u", "User", "hi")
     sent_body = ctx.matrix.sent[-1][1]
     assert sent_body.endswith("hello world")

--- a/tests/test_handlers_reset_prompt_x.py
+++ b/tests/test_handlers_reset_prompt_x.py
@@ -33,6 +33,12 @@ async def _to_thread(fn, *a, **kw):
     return fn(*a, **kw)
 
 
+def _make_send_response(matrix):
+    async def send_response(room_id, body, html=None):
+        await matrix.send_text(room_id, body, html=html)
+    return send_response
+
+
 @pytest.mark.asyncio
 async def test_handle_reset_stock_and_default():
     ctx = SimpleNamespace(
@@ -87,6 +93,7 @@ async def test_handle_persona_and_custom():
         render=lambda s: None,
         log=lambda *a, **k: None,
     )
+    ctx.send_response = _make_send_response(ctx.matrix)
     room = "!r"
     user = "@u"
     await handle_persona(ctx, room, user, "User", "detective")
@@ -116,6 +123,7 @@ async def test_handle_x_resolves_display_name_and_replies():
         render=lambda s: None,
         log=lambda *a, **k: None,
     )
+    ctx.send_response = _make_send_response(ctx.matrix)
     # Seed history for target so handler proceeds
     ctx.history.add(room, target, "user", "hi")
     await handle_x(ctx, room, sender, names[sender], f"{names[target]} what up")
@@ -143,6 +151,7 @@ async def test_handle_x_supports_display_names_with_spaces():
         render=lambda s: None,
         log=lambda *a, **k: None,
     )
+    ctx.send_response = _make_send_response(ctx.matrix)
     # Seed known participants for resolution
     ctx.history.add(room, john, "user", "hi")
     ctx.history.add(room, jane, "user", "hello")
@@ -171,6 +180,7 @@ async def test_handle_x_keeps_matrix_id_targeting():
         render=lambda s: None,
         log=lambda *a, **k: None,
     )
+    ctx.send_response = _make_send_response(ctx.matrix)
     ctx.history.add(room, target, "user", "init")
 
     await handle_x(ctx, room, sender, "Sender", "@target:hs hello")

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -20,11 +20,9 @@ def make_cfg(markdown=True):
 
 
 def test_render_html_success(monkeypatch):
-    class FakeMarkdownMod:
-        def markdown(self, text, extensions=None):
-            return "<p>" + text + "</p>"
+    import ollamarama.markdown_utils as mu
 
-    monkeypatch.setitem(sys.modules, "markdown", FakeMarkdownMod())
+    monkeypatch.setattr(mu, "render_markdown", lambda body: "<p>" + body + "</p>")
     # Patch matrix client deps so AppContext can construct without nio
     class _FakeCfg:
         def __init__(self, **kw):

--- a/tests/test_tools_mcp.py
+++ b/tests/test_tools_mcp.py
@@ -98,6 +98,12 @@ async def _to_thread(fn, *a, **kw):
     return fn(*a, **kw)
 
 
+def _make_send_response(matrix):
+    async def send_response(room_id, body, html=None):
+        await matrix.send_text(room_id, body, html=html)
+    return send_response
+
+
 @pytest.mark.asyncio
 async def test_handle_ai_with_tools():
     schema = load_schema()
@@ -118,6 +124,7 @@ async def test_handle_ai_with_tools():
     )
     ctx.respond_with_tools = AppContext.respond_with_tools.__get__(ctx)
     ctx._execute_tool = AppContext._execute_tool.__get__(ctx)
+    ctx.send_response = _make_send_response(ctx.matrix)
     await handle_ai(ctx, "!r", "@u", "User", "what is 2+2")
     sent_body = ctx.matrix.sent[-1][1]
     assert "4" in sent_body


### PR DESCRIPTION
## Summary

Alternate approach to #67 for the thinking indicator requested in #66.

Instead of emoji reactions on the user's message, this sends a placeholder message immediately when a command is received, animates it with a bouncing dot-wave while the LLM generates, then edits it in-place with the actual response:

```
Username:
Thinking.   →   Thinking..   →   Thinking...   →   Thinking..   →   (repeat)
```

When the response arrives, that same message is edited to show the final reply under the same `**Username:**` header — so the conversation flow reads naturally and no separate cleanup step is needed.

- `matrix_client.py` — `send_text` now returns event ID; new `edit_message` using `m.replace`
- `app_context.py` — `send_response()` edits the placeholder if one exists, otherwise sends new; animation task tracked and cancelled on response
- `app_runtime.py` — sends placeholder and starts dot-wave animation task before dispatching generating handlers
- Handlers use `ctx.send_response()` for both success and error paths

Also includes the markdown list rendering fixes and `default_model` resolution fix from the emoji branch.

Closes #66 (alternate solution — see that issue for discussion of which approach to keep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)