### PR TITLE
Add admin toggle for thinking placeholder (v1.3.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Common commands (see [Commands](docs/commands.md) for the full list):
 | `.clear` (admin) | Reset globally for all users | `.clear` |
 | `.help` | Show inline help | `.help` |
 | `.verbose [on,off,toggle]` (admin) | Control inclusion of brevity clause for new conversations | `.verbose on` |
+| `.thinking [on,off,toggle]` (admin) | Show or hide the thinking placeholder while generating | `.thinking off` |
 
 ## Encryption Support
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -17,5 +17,6 @@ Users can interact with the bot using dot‑commands or by mentioning the bot na
 - `.model [name|reset]` — Show/change the active model. `reset` restores default.
 - `.clear` — Reset the bot globally for all users.
 - `.verbose [on|off|toggle]` — Omit or include the brevity clause for new conversations.
+- `.thinking [on|off|toggle]` — Show or hide the thinking placeholder while the bot is generating a response.
 
 Tip: Admin privileges are based on the sender display name matching one of the configured `matrix.admins` entries.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,6 +21,7 @@ Ollamarama reads a JSON configuration file (default `./config.json`). You can ov
   - history_size: 1–1000 messages retained per user per room
   - options: advanced generation options (e.g., `temperature`, `top_p`, `repeat_penalty`)
   - verbose: boolean, when true omit the optional brevity clause for new conversations
+  - thinking: boolean, when true show an animated thinking placeholder while generating (default: true)
   - mcp_servers: mapping of names to MCP server specs for tool calling (optional)
     - Accepts multiple formats per server:
       - String URL: `"http://localhost:9000"`

--- a/help.md
+++ b/help.md
@@ -25,3 +25,4 @@ Project: https://github.com/h1ddenpr0cess20/ollamarama-matrix
 | `.model [name or reset]` | No args: show current and available models. With `name`: change model. Use `reset` to restore default. | `.model qwen3` |
 | `.clear` | Reset the bot for everyone in the room(s). | `.clear` |
 | `.verbose [on|off|toggle]` | Control inclusion of the brevity clause for new conversations. | `.verbose on` |
+| `.thinking [on|off|toggle]` | Show or hide the thinking placeholder while the bot is generating a response. | `.thinking off` |

--- a/ollamarama/__init__.py
+++ b/ollamarama/__init__.py
@@ -4,4 +4,4 @@ Provides the CLI and application modules for the Matrix bot.
 """
 
 __all__ = ["__version__"]
-__version__ = "1.3.0"
+__version__ = "1.3.1"

--- a/ollamarama/app_context.py
+++ b/ollamarama/app_context.py
@@ -127,6 +127,10 @@ class AppContext:
             self.history.set_verbose(self.verbose)
         except Exception:
             pass
+        try:
+            self.thinking = bool(getattr(cfg.ollama, "thinking", True))
+        except Exception:
+            self.thinking = True
 
     def _load_builtin_tools_schema(self) -> List[Dict[str, Any]]:
         """Load builtin tools schema definitions.

--- a/ollamarama/app_router.py
+++ b/ollamarama/app_router.py
@@ -35,6 +35,12 @@ def _build_router() -> Router:
         router.register(".verbose", handle_verbose, admin=True)
     except Exception:
         pass
+    try:
+        from .handlers.cmd_thinking import handle_thinking
+
+        router.register(".thinking", handle_thinking, admin=True)
+    except Exception:
+        pass
     return router
 
 

--- a/ollamarama/app_runtime.py
+++ b/ollamarama/app_runtime.py
@@ -193,7 +193,7 @@ def _make_text_handler(
             except Exception:
                 pass
             user_event_id = getattr(event, "event_id", None)
-            if handler in _GENERATING_HANDLERS and user_event_id:
+            if handler in _GENERATING_HANDLERS and user_event_id and getattr(ctx, "thinking", True):
                 label = f"**{sender_display}**:"
                 initial_body = f"{label}\n{_SPINNER_PREFIX}{_SPINNER_FRAMES[0]}"
                 event_id = await ctx.matrix.send_text(

--- a/ollamarama/config.py
+++ b/ollamarama/config.py
@@ -32,6 +32,7 @@ class OllamaConfig:
     mcp_servers: Dict[str, Any] = field(default_factory=dict)
     # When True, omit the optional brevity clause (third prompt element) from new conversations
     verbose: bool = False
+    thinking: bool = True
 
 
 @dataclass
@@ -165,6 +166,7 @@ def load_config(
             timeout=360,
             mcp_servers=dict(ollama.get("mcp_servers", {})),
             verbose=bool(ollama.get("verbose", False)),
+            thinking=bool(ollama.get("thinking", True)),
         ),
         markdown=bool(raw.get("markdown", True)),
     )

--- a/ollamarama/handlers/cmd_thinking.py
+++ b/ollamarama/handlers/cmd_thinking.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+async def handle_thinking(ctx: Any, room_id: str, sender_id: str, sender_display: str, args: str) -> None:
+    """Admin command to view or change the thinking placeholder.
+
+    Usage: `.thinking [on|off|toggle]`.
+    """
+    arg = (args or "").strip().lower()
+    if arg in ("", "status"):
+        state = "ON" if getattr(ctx, "thinking", True) else "OFF"
+        body = f"Thinking placeholder is **{state}**"
+        html = ctx.render(body)
+        await ctx.matrix.send_text(room_id, body, html=html)
+        return
+
+    new_state: bool | None = None
+    if arg in ("on", "true", "1", "enable", "enabled"):
+        new_state = True
+    elif arg in ("off", "false", "0", "disable", "disabled"):
+        new_state = False
+    elif arg in ("toggle", "switch"):
+        new_state = not bool(getattr(ctx, "thinking", True))
+    else:
+        body = "Usage: .thinking [on|off|toggle]"
+        html = ctx.render(body)
+        await ctx.matrix.send_text(room_id, body, html=html)
+        return
+
+    ctx.thinking = bool(new_state)
+    state = "ON" if ctx.thinking else "OFF"
+    body = f"Thinking placeholder set to **{state}**"
+    try:
+        ctx.log(body)
+    except Exception:
+        pass
+    html = ctx.render(body)
+    await ctx.matrix.send_text(room_id, body, html=html)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ollamarama-matrix"
-version = "1.3.0"
+version = "1.3.1"
 description = "Matrix chatbot powered by Ollama"
 readme = "README.md"
 requires-python = ">=3.7"


### PR DESCRIPTION
## Summary

- Adds `.thinking [on|off|toggle]` admin command to enable/disable the animated thinking placeholder at runtime
- Adds `ollama.thinking` config key (default: `true`) for startup-time override
- Bumps version to 1.3.1
- Updates `help.md`, `README.md`, `docs/commands.md`, and `docs/configuration.md`

## Test plan

- [ ] `.thinking off` disables the placeholder — bot responds directly without the dot-wave animation
- [ ] `.thinking on` re-enables it
- [ ] `.thinking toggle` flips the current state
- [ ] `.thinking` (no args) reports current state
- [ ] Non-admin users cannot use `.thinking`
- [ ] `ollama.thinking: false` in config.json starts the bot with placeholder disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)