### PR TITLE
Fix encryption after restart by removing logout call

### DIFF
--- a/ollamarama/matrix_client.py
+++ b/ollamarama/matrix_client.py
@@ -225,12 +225,15 @@ class MatrixClientWrapper:
         await self.client.sync_forever(timeout=timeout_ms, full_state=True)
 
     async def shutdown(self) -> None:
-        """Best-effort logout/close of the underlying client."""
-        try:
-            if hasattr(self.client, "logout"):
-                await self.client.logout()  # type: ignore[arg-type]
-        except Exception:
-            pass
+        """Best-effort close of the underlying client.
+
+        Deliberately does NOT call ``logout()``: logging out deletes the
+        device and its keys server-side, while the local store keeps the olm
+        account marked as shared, so nio never re-uploads identity keys and
+        the bot can no longer decrypt anything in encrypted rooms after a
+        restart (see issue #75). Closing the connection keeps the device and
+        access token valid so the encryption store stays usable.
+        """
         try:
             if hasattr(self.client, "close"):
                 await self.client.close()  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

Remove the `logout()` call from the shutdown method to prevent device deletion server-side, which was causing encryption keys to become unusable after bot restart. The connection will now be cleanly closed while preserving the device and access token.

## Changes

- Removed `logout()` call from `shutdown()` method that was deleting the device server-side
- Updated docstring to explain why logout is deliberately avoided and the implications for encryption store persistence
- Kept the `close()` call to cleanly close the client connection

## Tests

No testing needed - this is a bug fix for issue #75 where the bot could not decrypt messages in encrypted rooms after restart. The change removes problematic code rather than adding new functionality.

## Checklist

- [x] Focused change (no unrelated edits)
- [x] Docs updated (docstring clarified with detailed explanation)
- [x] No secrets or sensitive data committed

https://claude.ai/code/session_01NsFiaJ9sqedqs3oEaHN3Di