### PR TITLE
Bump version to 1.6.1

### DIFF
--- a/ollamarama/__init__.py
+++ b/ollamarama/__init__.py
@@ -4,4 +4,4 @@ Provides the CLI and application modules for the Matrix bot.
 """
 
 __all__ = ["__version__"]
-__version__ = "1.6.0"
+__version__ = "1.6.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ollamarama-matrix"
-version = "1.6.0"
+version = "1.6.1"
 description = "Matrix chatbot powered by Ollama"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Patch release bumping version 1.6.0 → 1.6.1.

Ships the fix from #76 (don't logout on shutdown; preserves the encryption store across restarts, fixes #75).