### PR TITLE
Sync repo README to Docker Hub description on publish

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -45,3 +45,10 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Update Docker Hub description
+        uses: peter-evans/dockerhub-description@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: ${{ env.IMAGE_NAME }}


### PR DESCRIPTION
Adds a `peter-evans/dockerhub-description` step to the Docker Hub publish workflow so the repo's `README.md` is pushed as the Docker Hub repository description on every publish, matching how the wordmark repo does it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)