### PR TITLE
Build multi-arch Docker image (add linux/arm64)

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -16,6 +16,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -40,6 +43,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Adds QEMU setup and `linux/arm64` to the Docker Hub build platforms, so ARM hosts (Apple Silicon, ARM servers) get a native image instead of falling back to emulation or failing to pull. Brings this workflow in line with the `agentirc` and `agent-smithers` publish workflows, which already build both arches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)