### PR TITLE
Harden CI/publish workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,11 +5,19 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-python@v5
         with:
@@ -24,12 +32,13 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -14,7 +14,7 @@ jobs:
     environment: pypi
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -29,3 +29,5 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true


### PR DESCRIPTION
Brings the CI and PyPI workflows in line with the hardening already in the `wordmark` CI workflow:

**CI (`ci.yml`)**
- `permissions: contents: read` — least-privilege token
- `concurrency` with `cancel-in-progress` — cancels superseded runs, saves minutes
- `timeout-minutes: 15` per job — kills hung runs
- `actions/checkout` v4 → v5

**Publish (`pypi-publish.yml`)**
- `skip-existing: true` — avoids failures when a version is already on PyPI
- `actions/checkout` v4 → v5

No change to what's tested/built. Python version matrix left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)