### PR TITLE
Add Dependabot and CodeQL; harden Docker Hub workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,38 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: ci
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: deps
+      prefix-development: deps-dev
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: docker

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -34,6 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,41 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze Python
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: python
+          queries: security-and-quality
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:python"

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -6,15 +6,23 @@ on:
     tags: ["v*"]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: dockerhub-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 env:
   IMAGE_NAME: ${{ secrets.DOCKERHUB_USERNAME }}/ollamarama-matrix
 
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
Summary

- Adds the two missing pieces of CI automation — Dependabot and CodeQL — and applies to `dockerhub.yml` the same hardening `ci.yml` and `pypi-publish.yml` already have. Lint and tests were already in place here, so no source changes.

Changes

- **`.github/dependabot.yml`** — weekly grouped updates for GitHub Actions, pip, and Docker. Grouped so each ecosystem opens one PR instead of a flood.
- **`codeql.yml`** — CodeQL analysis for Python on PRs, pushes to `main`, and a Monday-morning schedule. `security-events: write` is scoped to the single job.
- **`dockerhub.yml`** — `permissions: contents: read`, a concurrency group with `cancel-in-progress: false` (a half-finished image push shouldn't be cancelled), a 45-minute timeout, and `checkout@v5` (was `v4`).
- **`ci.yml`** — added `workflow_dispatch`, and `fail-fast: false` on the test matrix so one Python version failing no longer masks the results of the others.

Tests

- `ruff check .` clean and all **124 tests pass** locally. No source files touched — this is workflow configuration only, so there is nothing new to add tests for.

Checklist

- [x] Focused change (no unrelated edits)
- [x] Tests added/updated as needed — config-only change, existing suite passes
- [x] Docs updated if behavior changed — no behavior change
- [x] No secrets or sensitive data committed

---
_Generated by [Claude Code](https://claude.ai/code/session_01L5zNU2DBe8UxK59ZtueLzF)_