### PR TITLE
Fix all CodeQL alerts

### DIFF
--- a/legacy/ollamarama.py
+++ b/legacy/ollamarama.py
@@ -97,7 +97,7 @@ class ollamarama(VerificationMixin):
         try:
             name = await self.client.get_displayname(user)
             return name.displayname
-        except:
+        except Exception:
             return user
 
     async def send_message(self, channel, message):
@@ -215,8 +215,10 @@ class ollamarama(VerificationMixin):
         """
         try:
             self.messages[channel][sender].clear()
-        except:
+        except Exception:
+            # No history recorded for this user yet, so there is nothing to clear.
             pass
+        prompt = self.prompt[0] + self.personality + self.prompt[1]
         if persona != None and persona != "":
             prompt = self.prompt[0] + persona + self.prompt[1]
         if custom != None  and custom != "":
@@ -247,7 +249,9 @@ class ollamarama(VerificationMixin):
                         username = await self.display_name(user)
                         if target == username:
                             target = user
-                    except:
+                    except Exception:
+                        # A display name that cannot be resolved simply does not match the
+                        # requested target.
                         pass
                 if target in self.messages[channel]:
                     await self.add_history("user", channel, target, message)
@@ -313,7 +317,9 @@ class ollamarama(VerificationMixin):
                     self.model = self.default_model
                 self.log(f"Model set to {self.model}")
                 await self.send_message(channel, f"Model set to **{self.model}**")
-            except:
+            except Exception:
+                # A failure here leaves the previous model selected; the user sees no
+                # confirmation, which is the signal that it did not take.
                 pass
         else:
             current_model = f"**Current model**: {self.model}\n**Available models**: {', '.join(sorted(list(self.models)))}"
@@ -386,7 +392,9 @@ class ollamarama(VerificationMixin):
                 try:
                     await self.allow_devices(sender)
                     await self.handle_message(message, sender, sender_display, channel)
-                except:
+                except Exception:
+                    # One bad message must not kill the sync loop; the next event is
+                    # still processed.
                     pass
 
 
@@ -398,6 +406,8 @@ class ollamarama(VerificationMixin):
         if self.device_id and hasattr(self.client, 'load_store') and callable(self.client.load_store):
             result = self.client.load_store()
             if asyncio.iscoroutine(result):
+                # Awaited purely for its effect; the store loads into the client.
+                # codeql[py/ineffectual-statement]
                 await result
 
         login_resp = await self.client.login(self.password, device_name=self.device_id)
@@ -415,6 +425,8 @@ class ollamarama(VerificationMixin):
                     json.dump(config, f, indent=4)
                     f.truncate()
             except Exception:
+                # Persisting the device id is an optimisation -- a fresh one is
+                # negotiated on the next login if this fails.
                 pass
 
         self.bot_id = await self.display_name(self.username)
@@ -424,7 +436,7 @@ class ollamarama(VerificationMixin):
                 await self.client.join(channel)
                 self.log(f"{self.bot_id} joined {channel}")
                 
-            except:
+            except Exception:
                 self.log(f"Couldn't join {channel}")
         
         self.client.add_event_callback(self.message_callback, RoomMessageText)

--- a/ollamarama/app_context.py
+++ b/ollamarama/app_context.py
@@ -52,6 +52,7 @@ class AppContext:
             for logger_name in ("fastmcp", "mcp", "mcp.server", "mcp.client", "openai.mcp"):
                 logging.getLogger(logger_name).setLevel(logging.ERROR)
         except Exception:
+            # Quieting third-party loggers is cosmetic; never let it break start-up.
             pass
 
     def _build_matrix_client(self, cfg: AppConfig) -> MatrixClientWrapper:
@@ -129,6 +130,8 @@ class AppContext:
         try:
             self.history.set_verbose(self.verbose)
         except Exception:
+            # The history store's verbosity hook is optional; the in-memory flag
+            # set above is the source of truth.
             pass
         try:
             self.thinking = bool(getattr(cfg.ollama, "thinking", True))
@@ -289,6 +292,8 @@ class AppContext:
             try:
                 await task
             except asyncio.CancelledError:
+                # Expected: we just cancelled the task and are draining its
+                # CancelledError so it is not reported as never-retrieved.
                 pass
         placeholder = self.thinking_placeholder_event_id
         self.thinking_placeholder_event_id = None
@@ -396,6 +401,7 @@ class AppContext:
                 log.info("Model requested %d tool call(s)", len(tool_calls))
                 log.debug("Requested tools: %s", [(tc.get("function") or {}).get("name") for tc in tool_calls])
             except Exception:
+                # Tool-call logging is diagnostic only and must not interrupt the loop.
                 pass
 
             messages.append(msg)

--- a/ollamarama/app_router.py
+++ b/ollamarama/app_router.py
@@ -34,12 +34,16 @@ def _build_router() -> Router:
 
         router.register(".verbose", handle_verbose, admin=True)
     except Exception:
+        # The .verbose command is optional; an older install without the
+        # handler module simply does not expose it.
         pass
     try:
         from .handlers.cmd_thinking import handle_thinking
 
         router.register(".thinking", handle_thinking, admin=True)
     except Exception:
+        # The .thinking command is optional; an older install without the
+        # handler module simply does not expose it.
         pass
     return router
 

--- a/ollamarama/app_runtime.py
+++ b/ollamarama/app_runtime.py
@@ -56,6 +56,8 @@ async def _persist_device_id_if_needed(ctx: AppContext, cfg: AppConfig, config_p
                 f.truncate()
             ctx.log(f"Persisted device_id to {config_path}")
     except Exception:
+        # Persisting the device id is an optimisation -- a fresh one is
+        # negotiated on the next login if this fails.
         pass
 
 
@@ -95,6 +97,8 @@ def _register_security_callbacks(ctx: AppContext) -> Security:
         )
         ctx.matrix.add_to_device_callback(security.log_to_device_event, None)
     except Exception:
+        # Verification callbacks are an E2EE nicety; nio builds without
+        # to-device callback support must not block startup.
         pass
     return security
 
@@ -114,8 +118,11 @@ def _setup_stop_event() -> asyncio.Event:
             try:
                 loop.add_signal_handler(sig, stop.set)
             except Exception:
+                # Signal handlers are unsupported on some platforms (notably
+                # Windows) and on non-main threads; fall back to default handling.
                 pass
     except Exception:
+        # No running loop yet, or the loop does not support signal handlers.
         pass
     return stop
 
@@ -132,6 +139,8 @@ async def _run_until_stopped(ctx: AppContext, stop: asyncio.Event) -> None:
     try:
         await asyncio.wait({sync_task, stop_task}, return_when=asyncio.FIRST_COMPLETED)
     except KeyboardInterrupt:
+        # Ctrl-C during the wait is a normal shutdown path; the finally
+        # block below performs the cleanup.
         pass
     finally:
         for t in (sync_task, stop_task):
@@ -196,10 +205,14 @@ def _make_text_handler(
             try:
                 ctx.log(f"{sender_display} ({sender}) sent {text} in {room.room_id}")  # type: ignore
             except Exception:
+                # Logging the inbound message is diagnostic only and must not stop
+                # the handler from running.
                 pass
             try:
                 await security.allow_devices(sender)
             except Exception:
+                # Device trust is best-effort; an undecryptable reply is better
+                # than dropping the message entirely.
                 pass
             user_event_id = getattr(event, "event_id", None)
             if handler in _GENERATING_HANDLERS and user_event_id and getattr(ctx, "thinking", True):
@@ -324,6 +337,7 @@ async def run(cfg: AppConfig, config_path: Optional[str] = None) -> None:
     try:
         ctx.log(login_resp)
     except Exception:
+        # Logging the login response is diagnostic only.
         pass
     await ctx.matrix.ensure_keys()
     await ctx.matrix.initial_sync()
@@ -352,10 +366,13 @@ async def run(cfg: AppConfig, config_path: Optional[str] = None) -> None:
             if hasattr(ctx.matrix, "shutdown"):
                 await ctx.matrix.shutdown()
         except Exception:
+            # Shutdown cleanup: the client may already be torn down, and the
+            # executor below must still be stopped.
             pass
         try:
             ctx.executor.shutdown(wait=False, cancel_futures=True)
         except Exception:
+            # Shutdown cleanup: the executor may already be shut down.
             pass
 
 

--- a/ollamarama/config.py
+++ b/ollamarama/config.py
@@ -181,6 +181,8 @@ def load_config(
                 merged.update(raw["mcp_servers"])
                 raw["ollama"]["mcp_servers"] = merged
     except Exception:
+        # The legacy top-level mcp_servers block is optional and best-effort
+        # to migrate; a malformed one is simply not merged.
         pass
 
     matrix = raw.get("matrix", {})
@@ -266,6 +268,8 @@ def validate_config(cfg: AppConfig) -> Tuple[bool, List[str]]:
             ):
                 errors.append("ollama.default_model must match a key or id in ollama.models")
         except Exception:
+            # Unusual model config shapes are reported by the checks above; this
+            # extra cross-check is skipped rather than raising during validation.
             pass
     if (
         not isinstance(cfg.ollama.prompt, list)

--- a/ollamarama/fastmcp_client.py
+++ b/ollamarama/fastmcp_client.py
@@ -116,6 +116,8 @@ class FastMCPClient:
                 try:
                     current.keep_alive = False
                 except Exception:
+                    # keep_alive is read-only on some transports; the default behaviour
+                    # is acceptable there.
                     pass
 
     def _mark_transport_stopped(self, transport: Any) -> None:
@@ -127,6 +129,8 @@ class FastMCPClient:
             try:
                 stop_event.set()
             except Exception:
+                # The event may already be set or belong to a closed loop; either way
+                # the transport is on its way down.
                 pass
 
     async def _list_tools_async(self) -> List[Dict[str, Any]]:

--- a/ollamarama/handlers/cmd_ai.py
+++ b/ollamarama/handlers/cmd_ai.py
@@ -42,6 +42,8 @@ async def handle_ai(ctx: Any, room_id: str, sender_id: str, sender_display: str,
             await ctx.send_response(room_id, "Something went wrong", html=ctx.render("Something went wrong"))
             ctx.log(e)
         except Exception:
+            # Best-effort cleanup on an already-failed request: if the error
+            # notice cannot be delivered either, there is nothing left to try.
             pass
         return
     response_text, thinking = split_thinking(response_text)
@@ -53,5 +55,6 @@ async def handle_ai(ctx: Any, room_id: str, sender_id: str, sender_display: str,
     try:
         ctx.log(f"Sending response to {sender_display} in {room_id}: {body}")
     except Exception:
+        # Logging is best-effort and must never suppress the reply itself.
         pass
     await ctx.send_response(room_id, body, html=html)

--- a/ollamarama/handlers/cmd_history.py
+++ b/ollamarama/handlers/cmd_history.py
@@ -47,6 +47,7 @@ async def handle_history(ctx: Any, room_id: str, sender_id: str, sender_display:
         try:
             ctx.log(f"Global history set to {state} by {sender_display} ({sender_id}) in {room_id}")
         except Exception:
+            # Logging is best-effort; the confirmation below still goes out.
             pass
         await ctx.matrix.send_text(room_id, body, html=ctx.render(body))
         return
@@ -80,5 +81,6 @@ async def handle_history(ctx: Any, room_id: str, sender_id: str, sender_display:
     try:
         ctx.log(f"History set to {state} for {sender_display} ({sender_id}) in {room_id}")
     except Exception:
+        # Logging is best-effort; the confirmation below still goes out.
         pass
     await ctx.matrix.send_text(room_id, body, html=ctx.render(body))

--- a/ollamarama/handlers/cmd_model.py
+++ b/ollamarama/handlers/cmd_model.py
@@ -29,6 +29,8 @@ async def handle_model(ctx: Any, room_id: str, sender_id: str, sender_display: s
         try:
             keys = sorted(list(ctx.models)) if isinstance(ctx.models, dict) else sorted(list(ctx.models))
         except Exception:
+            # An unexpected models container just yields an empty list, which the
+            # message below renders as "no models".
             pass
         body = f"**Current model**: {ctx.model}\n**Available models**: {', '.join(keys)}"
         html = ctx.render(body)
@@ -45,6 +47,8 @@ async def handle_model(ctx: Any, room_id: str, sender_id: str, sender_display: s
             else:
                 ctx.model = arg
         except Exception:
+            # A models container that cannot be indexed leaves the active model
+            # unchanged; the confirmation below still reports the real value.
             pass
 
     body = f"Model set to **{ctx.model}**"

--- a/ollamarama/handlers/cmd_prompt.py
+++ b/ollamarama/handlers/cmd_prompt.py
@@ -29,6 +29,8 @@ async def handle_persona(ctx: Any, room_id: str, sender_id: str, sender_display:
         prompt = f"{ctx.history.prompt_prefix}{persona or ctx.history.personality}{ctx.history.prompt_suffix}"
         ctx.log(f"System prompt for {sender_display} ({sender_id}) set to '{prompt}'")
     except Exception:
+        # Echoing the assembled prompt is diagnostic only; the prompt itself
+        # was already stored by init_prompt above.
         pass
     ctx.history.add(room_id, sender_id, "user", "introduce yourself")
     await _respond(ctx, room_id, sender_id, sender_display)
@@ -58,6 +60,7 @@ async def handle_custom(ctx: Any, room_id: str, sender_id: str, sender_display: 
     try:
         ctx.log(f"System prompt for {sender_display} ({sender_id}) set to '{custom}'")
     except Exception:
+        # Logging is best-effort; the prompt was already stored above.
         pass
     ctx.history.add(room_id, sender_id, "user", "introduce yourself")
     await _respond(ctx, room_id, sender_id, sender_display)
@@ -90,6 +93,8 @@ async def _respond(ctx: Any, room_id: str, user_id: str, header_display: str) ->
             await ctx.send_response(room_id, "Something went wrong", html=ctx.render("Something went wrong"))
             ctx.log(e)
         except Exception:
+            # Best-effort cleanup on an already-failed request: if the error
+            # notice cannot be delivered either, there is nothing left to try.
             pass
         return
     response_text = data.get("message", {}).get("content") or ""
@@ -98,6 +103,7 @@ async def _respond(ctx: Any, room_id: str, user_id: str, header_display: str) ->
         try:
             ctx.log(f"Model thinking for {header_display} ({user_id}): {thinking}")
         except Exception:
+            # Logging the model's reasoning is diagnostic only.
             pass
     ctx.history.add(room_id, user_id, "assistant", response_text)
     body = f"**{header_display}**:\n{response_text}"
@@ -105,5 +111,6 @@ async def _respond(ctx: Any, room_id: str, user_id: str, header_display: str) ->
     try:
         ctx.log(f"Sending response to {header_display} in {room_id}: {body}")
     except Exception:
+        # Logging is best-effort and must never suppress the reply itself.
         pass
     await ctx.send_response(room_id, body, html=html)

--- a/ollamarama/handlers/cmd_reset.py
+++ b/ollamarama/handlers/cmd_reset.py
@@ -27,6 +27,7 @@ async def handle_reset(ctx: Any, room_id: str, sender_id: str, sender_display: s
         try:
             ctx.log(f"Stock settings applied for {sender_display} in {room_id}")
         except Exception:
+            # Logging is best-effort; the confirmation below still goes out.
             pass
         await ctx.matrix.send_text(room_id, body, html=ctx.render(body))
     else:
@@ -34,6 +35,7 @@ async def handle_reset(ctx: Any, room_id: str, sender_id: str, sender_display: s
         try:
             ctx.log(f"{ctx.bot_id} reset to default for {sender_display} in {room_id}")
         except Exception:
+            # Logging is best-effort; the confirmation below still goes out.
             pass
         await ctx.matrix.send_text(room_id, body, html=ctx.render(body))
 
@@ -61,5 +63,6 @@ async def handle_clear(ctx: Any, room_id: str, sender_id: str, sender_display: s
     try:
         ctx.log("Bot has been reset for everyone")
     except Exception:
+        # Logging is best-effort; the confirmation below still goes out.
         pass
     await ctx.matrix.send_text(room_id, body, html=ctx.render(body))

--- a/ollamarama/handlers/cmd_thinking.py
+++ b/ollamarama/handlers/cmd_thinking.py
@@ -35,6 +35,7 @@ async def handle_thinking(ctx: Any, room_id: str, sender_id: str, sender_display
     try:
         ctx.log(body)
     except Exception:
+        # Logging is best-effort; the confirmation below still goes out.
         pass
     html = ctx.render(body)
     await ctx.matrix.send_text(room_id, body, html=html)

--- a/ollamarama/handlers/cmd_verbose.py
+++ b/ollamarama/handlers/cmd_verbose.py
@@ -37,12 +37,15 @@ async def handle_verbose(ctx: Any, room_id: str, sender_id: str, sender_display:
     try:
         ctx.history.set_verbose(ctx.verbose)
     except Exception:
+        # The history store's verbosity hook is optional; the in-memory flag
+        # above is the source of truth.
         pass
     state = "ON" if ctx.verbose else "OFF"
     body = f"Verbose mode set to **{state}**"
     try:
         ctx.log(body)
     except Exception:
+        # Logging is best-effort; the confirmation below still goes out.
         pass
     html = ctx.render(body)
     await ctx.matrix.send_text(room_id, body, html=html)

--- a/ollamarama/handlers/cmd_x.py
+++ b/ollamarama/handlers/cmd_x.py
@@ -75,6 +75,8 @@ async def handle_x(ctx: Any, room_id: str, sender_id: str, sender_display: str, 
             await ctx.send_response(room_id, "Something went wrong", html=ctx.render("Something went wrong"))
             ctx.log(e)
         except Exception:
+            # Best-effort cleanup on an already-failed request: if the error
+            # notice cannot be delivered either, there is nothing left to try.
             pass
         return
     response_text = data.get("message", {}).get("content") or ""
@@ -87,5 +89,6 @@ async def handle_x(ctx: Any, room_id: str, sender_id: str, sender_display: str, 
     try:
         ctx.log(f"Sending response to {sender_display} in {room_id}: {body}")
     except Exception:
+        # Logging is best-effort and must never suppress the reply itself.
         pass
     await ctx.send_response(room_id, body, html=html)

--- a/ollamarama/matrix_client.py
+++ b/ollamarama/matrix_client.py
@@ -54,6 +54,8 @@ class MatrixClientWrapper:
         try:
             self.client.user_id = username  # type: ignore[attr-defined]
         except Exception:
+            # Some nio versions expose ``user_id`` as a read-only property; the
+            # client derives it from the login response either way.
             pass
         self.password = password
 
@@ -72,6 +74,8 @@ class MatrixClientWrapper:
         if callable(result):
             maybe = result()
             if asyncio.iscoroutine(maybe):
+                # Awaited purely for its effect; the store loads into the client.
+                # codeql[py/ineffectual-statement]
                 await maybe
 
     async def join(self, room_id: str) -> None:
@@ -104,6 +108,8 @@ class MatrixClientWrapper:
         try:
             await request(event)
         except Exception:
+            # Best-effort key request; the message stays undecryptable and the
+            # caller has already surfaced that to the user.
             pass
 
     async def send_text(self, room_id: str, body: str, html: Optional[str] = None) -> Optional[str]:
@@ -148,6 +154,8 @@ class MatrixClientWrapper:
                 room_id=room_id, message_type="m.room.message", content=content, ignore_unverified_devices=True
             )
         except Exception:
+            # An edit that cannot be delivered is not worth failing the whole
+            # response over -- the original message is already in the room.
             pass
 
     async def display_name(self, user_id: str) -> str:
@@ -206,6 +214,8 @@ class MatrixClientWrapper:
         try:
             self.client.add_to_device_callback(callback, event_types)
         except Exception:
+            # Older nio builds do not accept an event-type filter (or lack the
+            # callback entirely); to-device handling is optional.
             pass
 
     async def initial_sync(self, timeout_ms: int = 3000) -> None:
@@ -238,4 +248,5 @@ class MatrixClientWrapper:
             if hasattr(self.client, "close"):
                 await self.client.close()  # type: ignore[arg-type]
         except Exception:
+            # Shutdown cleanup: the transport may already be torn down.
             pass

--- a/ollamarama/ollama_client.py
+++ b/ollamarama/ollama_client.py
@@ -142,6 +142,8 @@ class OllamaClient:
             if r.ok:
                 return True
         except requests.RequestException:
+            # This endpoint is one of several probed in turn; a connection
+            # failure just means trying the next one below.
             pass
         try:
             r = self._session.head(f"{self.base_url}/chat", timeout=5)
@@ -182,6 +184,8 @@ class OllamaClient:
                 if isinstance(name, str) and name:
                     models[name] = name
         except Exception:
+            # An unexpected payload shape yields no models, which the caller
+            # below already treats as "nothing discovered".
             pass
         if not models:
             raise RuntimeFailure("No models found in Ollama /tags response")

--- a/ollamarama/security.py
+++ b/ollamarama/security.py
@@ -6,7 +6,6 @@ from typing import Any, Optional
 
 try:
     from nio import (
-        KeyVerificationEvent,
         KeyVerificationStart,
         KeyVerificationKey,
         KeyVerificationMac,
@@ -14,7 +13,6 @@ try:
         ToDeviceMessage,
     )
 except Exception:  # pragma: no cover
-    KeyVerificationEvent = object  # type: ignore
     KeyVerificationStart = object  # type: ignore
     KeyVerificationKey = object  # type: ignore
     KeyVerificationMac = object  # type: ignore
@@ -116,6 +114,8 @@ class Security:
                     elif hasattr(client, "send_sas_mac"):
                         await client.send_sas_mac(event.transaction_id)  # type: ignore[attr-defined]
                 except Exception:
+                    # Nio spells the MAC step differently across versions; if none of the
+                    # three shapes is available there is no MAC to send.
                     pass
 
                 try:
@@ -127,6 +127,8 @@ class Security:
                     )
                     await client.to_device(done)
                 except Exception:
+                    # The peer may have already completed or cancelled the exchange, in
+                    # which case the done message has nowhere to go.
                     pass
                 self.logger.info("Emoji verification was successful.")
             elif isinstance(event, KeyVerificationCancel):
@@ -155,6 +157,8 @@ class Security:
             if hasattr(c, "keys_query"):
                 await c.keys_query()  # type: ignore[func-returns-value]
         except Exception:
+            # Key querying is optional; the device store may already be populated
+            # from a previous sync.
             pass
         try:
             for device in self._user_devices(c, user_id):
@@ -170,8 +174,11 @@ class Security:
                     dev_id = getattr(device, "device_id", None) or getattr(device, "id", "?")
                     self.logger.info("verified device %s for %s", dev_id, user_id)
                 except Exception:
+                    # One device failing to verify must not stop the remaining devices
+                    # from being processed.
                     pass
         except Exception:
+            # No usable device store on this client build; nothing to verify.
             pass
 
     @staticmethod
@@ -189,6 +196,7 @@ class Security:
             try:
                 return list(active(user_id))
             except Exception:
+                # Fall through to reading the device store directly below.
                 pass
         devices = getattr(store, "devices", {})
         try:

--- a/ollamarama/thinking.py
+++ b/ollamarama/thinking.py
@@ -30,6 +30,7 @@ def split_thinking(text: str) -> Tuple[str, str]:
             thinking_parts.append(thinking.replace("<think>", "").strip())
             text = rest
         except Exception:
+            # Malformed reasoning markers just mean the text is left as-is.
             pass
 
     if "<|begin_of_thought|>" in text and "<|end_of_thought|>" in text:
@@ -41,12 +42,14 @@ def split_thinking(text: str) -> Tuple[str, str]:
                 )
                 text = parts[1]
         except Exception:
+            # Malformed reasoning markers just mean the text is left as-is.
             pass
 
     if "<|begin_of_solution|>" in text and "<|end_of_solution|>" in text:
         try:
             text = text.split("<|begin_of_solution|>", 1)[1].split("<|end_of_solution|>", 1)[0]
         except Exception:
+            # Malformed solution markers just mean the text is left as-is.
             pass
 
     return text.strip(), "\n".join(t for t in thinking_parts if t)

--- a/tests/test_handlers_model_ai_help.py
+++ b/tests/test_handlers_model_ai_help.py
@@ -128,5 +128,7 @@ async def test_handle_help_splits_admin_section():
     ctx.matrix.sent.clear()
     await handle_help(ctx, "!r", "@u", "Admin", "")
     assert len(ctx.matrix.sent) >= 1
-    if "~~~" in open("help.md").read():
+    with open("help.md") as handle:
+        help_text = handle.read()
+    if "~~~" in help_text:
         assert len(ctx.matrix.sent) == 2


### PR DESCRIPTION
Summary

- Clears all 70 CodeQL `security-and-quality` alerts on this repo, including one that was a real crash: `.persona` with no argument raised `NameError` in the legacy bot.

Changes

- **`py/uninitialized-local-variable` (1, error)** — `set_prompt` only bound `prompt` inside its `persona` and `custom` branches, so calling `.persona` with an empty argument fell through to `add_history("system", channel, sender, prompt)` with `prompt` unbound. It now starts from `self.prompt[0] + self.personality + self.prompt[1]`, matching what `add_history` seeds for a new conversation and what `handlers/cmd_prompt.py` does today.
- **`py/catch-base-exception` (6)** — the legacy bot's bare `except:` clauses also caught `KeyboardInterrupt` and `SystemExit`. One of them wraps the whole per-message handler inside the sync loop, so Ctrl-C during message handling was being swallowed. Narrowed all six to `except Exception:`.
- **`py/empty-except` (59)** — documented each handler that intentionally swallows an exception. Mostly best-effort logging around a reply, optional client capabilities, and shutdown cleanup.
- **`py/unused-import` (1)** — `security.py` imported `KeyVerificationEvent` but never used it; `app_runtime` imports its own copy.
- **`py/file-not-closed` (1)** — the `help.md` read in `test_handlers_model_ai_help` now uses a `with` block.
- **`py/ineffectual-statement` (2)** — `await coro` as a bare statement; the query's `hasSideEffects()` does not model `Await`, so it reads as dead code. Suppressed at both sites with a note rather than contorting idiomatic code.

Tests

- `pytest`: 124 passed. `ruff check .`: clean.
- Re-ran the same CodeQL suite `.github/workflows/codeql.yml` uses (Python, `security-and-quality`): **70 alerts → 0 open**, 2 suppressed (the `await` false positives above).
- No new tests. The `set_prompt` fix is in `legacy/`, which has no test coverage in this repo; the rest are comments and non-behavioral edits. Worth flagging in case you'd rather that path got a regression test.

Checklist

- [x] Focused change (no unrelated edits)
- [x] Tests added/updated as needed — see the note above on `legacy/`
- [x] Docs updated if behavior changed
- [x] No secrets or sensitive data committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VCBEBtZ3E4gUfRkF1cGaig

---
_Generated by [Claude Code](https://claude.ai/code/session_01VCBEBtZ3E4gUfRkF1cGaig)_